### PR TITLE
Also implement Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ impl<T> SendWrapper<T> {
 }
 
 unsafe impl<T> Send for SendWrapper<T> { }
+unsafe impl<T> Sync for SendWrapper<T> { }
 
 impl<T> Deref for SendWrapper<T> {
 	type Target = T;


### PR DESCRIPTION
Right now `SendWrapper<T>` doesn't implement `Sync` unless `T` is `Sync`.
Considering that only one thread can access it anyway, I don't think there's a reason why this is not the case.

The use-case that I have in mind is `Arc<SendWrapper<T>>`.
