### PR TITLE
Use thread-local storage in `valid()`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,12 @@
+#![feature(test)]
+
+extern crate test;
+
+use send_wrapper::SendWrapper;
+use test::Bencher;
+
+#[bench]
+fn bench_deref(b: &mut Bencher) {
+	let x = SendWrapper::new(42);
+	b.iter(|| *x);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ impl<T> SendWrapper<T> {
 		}
 	}
 
+	#[cfg(feature = "futures-core")]
 	#[track_caller]
 	fn assert_valid_for_poll(&self) {
 		if !self.valid() {
@@ -270,6 +271,7 @@ fn invalid_deref() -> ! {
 	panic!("{}", DEREF_ERROR)
 }
 
+#[cfg(feature = "futures-core")]
 #[cold]
 #[inline(never)]
 #[track_caller]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,13 @@ impl<T> SendWrapper<T> {
 
 	/// Returns `true` if the value can be safely accessed from within the current thread.
 	pub fn valid(&self) -> bool {
-		self.thread_id == thread::current().id()
+		// Cache the current thread ID as an optimization, to avoid cloning and dropping an Arc
+		// internally each time we access it. If `std::thread::current_id` is eventually
+		// stabilized, we can remove this `thread_local!` and just call that directly.
+		std::thread_local! {
+			static CURRENT_THREAD_ID: ThreadId = thread::current().id();
+		}
+		CURRENT_THREAD_ID.with(|current| *current == self.thread_id)
 	}
 
 	/// Takes the value out of the `SendWrapper<T>`.


### PR DESCRIPTION
Three commits in this PR:
1. Fix a couple of unused code warnings.
2. Add a benchmark for `SendWrapper::deref`.
3. Improve that benchmark by caching the current thread ID in thread-local storage.

Before the third commit, `bench_deref` (the new benchmark) is 7.52 ns/iter on my machine. After, it's 0.18 ns/iter. I think the difference is that `thread::current().id()` always clones and drops an `Arc` internally, while the new version is two non-atomic loads and a predictable branch in the hot (initialized) path.

As far as I can tell, the only difference between this approach and what the nightly-only [`std::thread::current_id`](https://doc.rust-lang.org/std/thread/fn.current_id.html) does, is that the latter is guaranteed not to allocate, even the first time you call it. I don't think that's a problem for this crate?