### PR TITLE
Expand CI testing to cover --no-default-features and benches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,14 +2,23 @@ name: Rust
 
 on: [push]
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build
       run: cargo build --all-features --verbose
     - name: Run tests
       run: cargo test --all-features --verbose
+    - name: Run tests (--no-default-features)
+      run: cargo test --no-default-features --verbose
+    - name: Check benchmarks
+      run: cargo check --all-targets --verbose
+      env:
+        RUSTC_BOOTSTRAP: "1"


### PR DESCRIPTION
Follow-up to https://github.com/thk1/send_wrapper/pull/15. If this is landed by itself, CI will be red because of the warnings in `master`, but #15 fixes those warnings. (In retrospect it would've made more sense for me to put that commit in this PR.)